### PR TITLE
Add docker entrypoint

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - production-branch
       - main
-      - database-info
+      - test-docker-entrypoint
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ USER ${USERNAME}:${USERNAME}
 RUN bundle exec rake RAILS_ENV=production assets:precompile
 
 EXPOSE 3000
-CMD bundle exec rails server -b "0.0.0.0" -p 3000
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,11 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
+gem 'faker'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
-  gem 'faker'
 end
 
 group :development do

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,5 +1,5 @@
 class PlantsController < ApplicationController
   def index
-    @plants = Plants.all
+    @plants = Plant.all
   end
 end

--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,5 +1,5 @@
 class PlantsController < ApplicationController
   def index
-    @plants = "There will be list of plans soon"
+    @plants = Plants.all
   end
 end

--- a/app/views/plants/index.html.erb
+++ b/app/views/plants/index.html.erb
@@ -1,5 +1,7 @@
-<h1>Plants Overview</h1>
+<h1>Plants</h1>
 
 <ul>
-    <%= @plants %>
+    <% @plants.each do |plant| %>
+        <li> <%= plant.name %> <li>
+    <% end %>
 <ul>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,17 +3,10 @@
 # Exit immediately if any command returns a non-zero status code
 set -e
 
-#echo "Running db:create"
-#bundle exec rake db:create
-
-#echo "Running db:schema:load"
-#bundle exec rake db:schema:load
-
 echo "Running db:migrate"
 bundle exec rake db:migrate
 
 echo "Running db:seed"
 bundle exec rake db:seed
 
-# Start the Rails server
 bundle exec rails server -b "0.0.0.0" -p 3000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env sh
-set -ex
+#!/bin/sh
 
+# Perform database migrations
+rails db:create
+
+# Start the Rails server
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Perform database migrations
-rails db:create
+rails db:migrate
 
 # Start the Rails server
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,14 +6,14 @@ set -e
 #echo "Running db:create"
 #bundle exec rake db:create
 
-echo "Running db:schema:load"
-bundle exec rake db:schema:load
+#echo "Running db:schema:load"
+#bundle exec rake db:schema:load
 
 echo "Running db:migrate"
 bundle exec rake db:migrate
 
-#echo "Running db:seed"
-#bundle exec rake db:seed
+echo "Running db:seed"
+bundle exec rake db:seed
 
 # Start the Rails server
 bundle exec rails server -b "0.0.0.0" -p 3000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 
-# Perform database migrations
-rails db:migrate
+# Exit immediately if any command returns a non-zero status code
+set -e
+
+echo "Running db:create"
+bundle exec rake db:create
+
+echo "Running db:schema:load"
+bundle exec rake db:schema:load
+
+echo "Running db:migrate"
+bundle exec rake db:migrate
+
+echo "Running db:seed"
+bundle exec rake db:seed
 
 # Start the Rails server
-exec "$@"
+bundle exec rails server -b "0.0.0.0" -p 3000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,8 +3,8 @@
 # Exit immediately if any command returns a non-zero status code
 set -e
 
-echo "Running db:create"
-bundle exec rake db:create
+#echo "Running db:create"
+#bundle exec rake db:create
 
 echo "Running db:schema:load"
 bundle exec rake db:schema:load
@@ -12,8 +12,8 @@ bundle exec rake db:schema:load
 echo "Running db:migrate"
 bundle exec rake db:migrate
 
-echo "Running db:seed"
-bundle exec rake db:seed
+#echo "Running db:seed"
+#bundle exec rake db:seed
 
 # Start the Rails server
 bundle exec rails server -b "0.0.0.0" -p 3000


### PR DESCRIPTION
The entrypoint is used to to run database-related commands and other setup tasks when the container is started rather than during the image build process, providing more flexibility and control over the initialization process.